### PR TITLE
added an outDir in the tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "system",
     "moduleResolution": "node",
     "sourceMap": true,
+    "outDir": "./dist",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,


### PR DESCRIPTION
**Before:** when you type in `npm start` it will mix the js files and .map files all around the project, on the same level as the `.ts` file; this is the default behavoir of `tsc`. This will become confusing if the project gets large.

**Now:** When you type in `npm start`, it will build everything into a `/dist` folder